### PR TITLE
Add additional properties to BulletinManager for flexible layouts

### DIFF
--- a/Sources/BulletinManager.swift
+++ b/Sources/BulletinManager.swift
@@ -79,11 +79,27 @@ import UIKit
     @objc public var cardPadding: BulletinPadding = .regular
 
     /**
+     * The spacing applied to the content stack view prepared by the Bulletin Item.
+     *
+     * Set this value if you'd like custom spacing. Otherwise sensible defaults will be applied.
+     */
+    
+    @objc public var cardContentSpacing: NSNumber?
+    
+    /**
+     * The padding around the card content stackView to the edge of the card
+     *
+     * Set this value if you'd like custom padding (e.g. none. Otherwise sensible defaults will be applied.
+     */
+    
+    public var cardContentInsets: UIEdgeInsets?
+
+    /**
      * The rounded corner radius of the bulletin card. Defaults to 12, and 36 on iPhone X.
      *
      * Set this value before calling `prepare`. Changing it after will have no effect.
      */
-
+    
     @objc public var cardCornerRadius: NSNumber?
 
     /**

--- a/Sources/Support/BulletinViewController.swift
+++ b/Sources/Support/BulletinViewController.swift
@@ -280,18 +280,18 @@ extension BulletinViewController {
 
         switch (traitCollection.verticalSizeClass, traitCollection.horizontalSizeClass) {
         case (.regular, .regular):
-            stackLeadingConstraint.constant = 32
-            stackTrailingConstraint.constant = -32
-            stackBottomConstraint.constant = -32
-            contentTopConstraint.constant = -32
-            contentStackView.spacing = 32
+            stackLeadingConstraint.constant = self.manager?.cardContentInsets?.left ?? 32
+            stackTrailingConstraint.constant = -1 * (self.manager?.cardContentInsets?.right ?? 32)
+            stackBottomConstraint.constant = -1 * (self.manager?.cardContentInsets?.bottom ?? 32)
+            contentTopConstraint.constant = -1 * (self.manager?.cardContentInsets?.top ?? 32)
+            contentStackView.spacing = CGFloat(self.manager?.cardContentSpacing ?? 32)
 
         default:
-            stackLeadingConstraint.constant = 24
-            stackTrailingConstraint.constant = -24
-            stackBottomConstraint.constant = -24
-            contentTopConstraint.constant = -24
-            contentStackView.spacing = 24
+            stackLeadingConstraint.constant = self.manager?.cardContentInsets?.left ?? 24
+            stackTrailingConstraint.constant = -1 * (self.manager?.cardContentInsets?.right ?? 24)
+            stackBottomConstraint.constant = -1 * (self.manager?.cardContentInsets?.bottom ?? 24)
+            contentTopConstraint.constant = -1 * (self.manager?.cardContentInsets?.top ?? 24)
+            contentStackView.spacing = CGFloat(self.manager?.cardContentSpacing ?? 24)
 
         }
 
@@ -408,9 +408,32 @@ extension BulletinViewController {
             defaultRadius = screenHasRoundedCorners ? 36 : 12
         }
 
+        let cornerRadius = CGFloat((manager?.cardCornerRadius ?? defaultRadius).doubleValue)
+        
+        if let customStackViewPadding = manager?.cardContentInsets {
+            let top = customStackViewPadding.top
+            let left = customStackViewPadding.left
+            let right = customStackViewPadding.right
+            let bottom = customStackViewPadding.bottom
+            
+            if top.isZero, left.isZero, right.isZero {
+                let topView = contentStackView.arrangedSubviews.first
+                if #available(iOS 11.0, *) {
+                    topView?.layer.maskedCorners = [.layerMinXMinYCorner, .layerMinXMinYCorner]
+                    topView?.layer.cornerRadius = cornerRadius
+                }
+            }
+            
+            if bottom.isZero, left.isZero, right.isZero  {
+                let lastView = contentStackView.arrangedSubviews.last
+                if #available(iOS 11.0, *) {
+                    lastView?.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+                    lastView?.layer.cornerRadius = cornerRadius
+                }
+            }
+        }
 
-
-        contentView.layer.cornerRadius = CGFloat((manager?.cardCornerRadius ?? defaultRadius).doubleValue)
+        contentView.layer.cornerRadius = cornerRadius
 
     }
 


### PR DESCRIPTION
This adds two properties to the `BulletinManager`:

1. `cardContentSpacing` - this updates the spacing that is applied to `contentStackView` in the `BulletinViewController`, previously hard-coded to 24 / 34, depending on the size class. 

2. `cardContentInsets` - this updates the default "padding" being applied to the `contentStackView` within the card itself. Again, depending on the size class, this will default to 24 or 32 unless provided. 

It also applies the same `cornerRadius` value to the top and bottom view corners if they're flush against the sides (if device OS allows). 