### PR TITLE
Allow custom dismissal buttons

### DIFF
--- a/Sources/BLTNItemManager.swift
+++ b/Sources/BLTNItemManager.swift
@@ -135,6 +135,12 @@ import UIKit
      */
 
     @objc public var allowsSwipeInteraction: Bool = true
+    
+    /**
+     * Optionally provide a custom button for the close button
+     */
+    
+    public var customCloseButton: UIButton?
 
 
     // MARK: - Private Properties

--- a/Sources/Support/BulletinViewController.swift
+++ b/Sources/Support/BulletinViewController.swift
@@ -128,6 +128,7 @@ extension BulletinViewController {
 
         // Close button
 
+        let closeButton: UIControl = self.manager?.customCloseButton ?? self.closeButton
         contentView.addSubview(closeButton)
         closeButton.translatesAutoresizingMaskIntoConstraints = false
         closeButton.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 12).isActive = true


### PR DESCRIPTION
Allows you to override the default dismiss buttons provided by the library. 